### PR TITLE
[+] fix -> add KongApi service definition

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -8,6 +8,10 @@ services:
         resource: '../../*'
         exclude: '../../{Entity}'
 
+    Adaniloff\KongUserBundle\Service\KongApi:
+        arguments:
+            - '@eight_points_guzzle.client.api_kong'
+
     kong_user.service.configuration:
         class: Adaniloff\KongUserBundle\Service\Configuration
         autowire: false


### PR DESCRIPTION
Because of invalid autowiring for Guzzle Client.